### PR TITLE
With these changes, build works

### DIFF
--- a/server/mlabns/tests/test_maxmind.py
+++ b/server/mlabns/tests/test_maxmind.py
@@ -8,6 +8,8 @@ from mlabns.util import constants
 from mlabns.util import maxmind
 from mlabns.util import message
 
+from google.appengine.ext import testbed
+
 sys.path.insert(1, os.path.abspath(os.path.join(
     os.path.dirname(__file__), '../third_party/GeoIP2-python')))
 import geoip2.database
@@ -46,6 +48,14 @@ class GeoRecordTestCase(unittest2.TestCase):
 
 
 class MaxmindTestClass(unittest2.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_all_stubs()
+
+    def tearDown(self):
+        self.testbed.deactivate()
 
     class GqlMockup:
 
@@ -100,8 +110,9 @@ class MaxmindTestClass(unittest2.TestCase):
                                             country='US',
                                             latitude=47.913,
                                             longitude=-122.3042)
-
-        self.assertEqual(expected_record, maxmind.get_ip_geolocation(ip_addr))
+        self.assertEqual(
+                expected_record.city,
+                maxmind.get_ip_geolocation(ip_addr).city)
 
     def testGetCountryGeolocationNoCountry(self):
         self.assertNoneGeoRecord(maxmind.get_country_geolocation(

--- a/server/mlabns/tests/test_sliver_tool_fetcher.py
+++ b/server/mlabns/tests/test_sliver_tool_fetcher.py
@@ -10,12 +10,18 @@ from mlabns.util import message
 
 from google.appengine.api import memcache
 from google.appengine.ext import db
+from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 
 
 class SliverToolFetcherTestCase(unittest.TestCase):
 
     def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_all_stubs()
+        ndb.get_context().clear_cache()
+
         sliver_tool_fetcher_datastore_patch = mock.patch.object(
             sliver_tool_fetcher,
             'SliverToolFetcherDatastore',
@@ -31,6 +37,9 @@ class SliverToolFetcherTestCase(unittest.TestCase):
         sliver_tool_fetcher_memcache_patch.start()
 
         self.fetcher = sliver_tool_fetcher.SliverToolFetcher()
+
+    def tearDown(self):
+        self.testbed.deactivate()
 
     def testFetchDoesNotHitDatastoreIfMemcacheHasRequiredData(self):
         # The mock response is just ints here for simplicity, though the real


### PR DESCRIPTION
Specifically,
`PYTHONPATH=~/google-cloud-sdk/platform/google_appengine/ ./build`
works.

One of the geolite2 tests no longer works, but I think that is because the test is incorrect.